### PR TITLE
directly append error msg to exception rather than using print

### DIFF
--- a/cvxpylayers/torch/cvxpylayer.py
+++ b/cvxpylayers/torch/cvxpylayer.py
@@ -247,11 +247,9 @@ def _CvxpyLayerFn(
             try:
                 xs, _, _, _, ctx.DT_batch = diffcp.solve_and_derivative_batch(
                     As, bs, cs, cone_dicts, **solver_args)
-            except diffcp.SolverError as e:
-                print(
-                    "Please consider re-formulating your problem so that "
-                    "it is always solvable.")
-                raise e
+            except diffcp.SolverError:
+                raise diffcp.SolverError("Please consider re-formulating your "
+                                         "problem so that it is always solvable.")
             info['solve_time'] = time.time() - start
 
             # extract solutions and append along batch dimension

--- a/cvxpylayers/torch/test_cvxpylayer.py
+++ b/cvxpylayers/torch/test_cvxpylayer.py
@@ -257,8 +257,10 @@ class TestCvxpyLayer(unittest.TestCase):
         prob = cp.Problem(cp.Minimize(param), [x >= 1, x <= -1])
         layer = CvxpyLayer(prob, [param], [x])
         param_tch = torch.ones(1)
-        with self.assertRaises(diffcp.SolverError):
+        with self.assertRaises(diffcp.SolverError) as cm:
             layer(param_tch)
+        excpt = cm.exception
+        assert "Please consider re-formulating your" in excpt.args[0]
 
     def test_unbounded(self):
         x = cp.Variable(1)
@@ -266,8 +268,10 @@ class TestCvxpyLayer(unittest.TestCase):
         prob = cp.Problem(cp.Minimize(x), [x <= param])
         layer = CvxpyLayer(prob, [param], [x])
         param_tch = torch.ones(1)
-        with self.assertRaises(diffcp.SolverError):
+        with self.assertRaises(diffcp.SolverError) as cm:
             layer(param_tch)
+        excpt = cm.exception
+        assert "Please consider re-formulating your" in excpt.args[0]
 
     def test_incorrect_parameter_shape(self):
         set_seed(243)


### PR DESCRIPTION
Hi! Great work on this, thank you so much!

On this PR I propose to get rid of a somewhat inconvenient `print` statement by directly appending the error message to the `SolverError` exception.  It also makes it easier to make sure that the correct exception is being caught via unit tests (like in https://github.com/cvxgrp/cvxpylayers/pull/38/commits/96b6578bd41695774e2134f97eeebbc2f052fee5#diff-a8b6747db9094c837316dbdf0755ff80R274).

Thanks!