### PR TITLE
Use CVXPY's dims to solver dict function in the TF layer

### DIFF
--- a/cvxpylayers/tensorflow/cvxpylayer.py
+++ b/cvxpylayers/tensorflow/cvxpylayer.py
@@ -1,6 +1,6 @@
-from cvxpylayers import utils
-
 import cvxpy as cp
+from cvxpy.reductions.solvers.conic_solvers.scs_conif import \
+    dims_to_solver_dict
 import diffcp
 import numpy as np
 
@@ -99,7 +99,7 @@ class CvxpyLayer(object):
             self.asa_maps = data[cp.settings.PARAM_PROB]
             self.param_ids = [p.id for p in self.params]
 
-        self.cones = utils.dims_to_solver_dict(data['dims'])
+        self.cones = dims_to_solver_dict(data['dims'])
         self.vars = variables
 
     def __call__(self, *parameters, solver_args={}):

--- a/cvxpylayers/utils.py
+++ b/cvxpylayers/utils.py
@@ -1,9 +1,0 @@
-def dims_to_solver_dict(cone_dims):
-    cones = {
-        "f": int(cone_dims.zero),
-        "l": int(cone_dims.nonpos),
-        "q": [int(v) for v in cone_dims.soc],
-        "ep": int(cone_dims.exp),
-        "s": [int(v) for v in cone_dims.psd]
-    }
-    return cones


### PR DESCRIPTION
CVXPY recently changed its internal cone dims representation

The PyTorch layer already uses CVXPY's internal function

Fixes  #58 