### PR TITLE
Remove email notifications from appveyor

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -20,12 +20,3 @@ build_script:
 
 test_script:
   - pytest
-
-notifications:
-  - provider: Email
-    to:
-      - stbarratt@gmail.com
-      - akshaykagrawal7@gmail.com
-    on_build_success: false
-    on_build_failure: true
-    on_build_status_changed: true


### PR DESCRIPTION
To prevent spam from forks

Shane, you may be able to add email notifications from the appveyor UI: https://help.appveyor.com/discussions/problems/14323-secure-email-notifications